### PR TITLE
Fix GH actions build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   test:
     name: Package and run all tests
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,4 +16,4 @@ jobs:
         distribution: 'adopt'
         java-version: '8'
     - name: Run Maven Targets
-      run: mvn test -Dtest=MultipleExecutionEnginesTest --batch-mode --show-version --no-transfer-progress 
+      run: mvn package --batch-mode --show-version --no-transfer-progress

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,8 +11,9 @@ jobs:
       with:
         fetch-depth: 0
     - name: Set up JDK
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
-        java-version: 8
+        distribution: 'adopt'
+        java-version: '8'
     - name: Run Maven Targets
       run: mvn test -Dtest=MultipleExecutionEnginesTest --batch-mode --show-version --no-transfer-progress 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,4 +15,4 @@ jobs:
       with:
         java-version: 8
     - name: Run Maven Targets
-      run: mvn package --batch-mode --show-version --no-transfer-progress
+      run: mvn test -Dtest=MultipleExecutionEnginesTest --batch-mode --show-version --no-transfer-progress 


### PR DESCRIPTION
For some unknown reason the GH actions build started to become flaky in the last few weeks. The main problem appears to be a series of timeouts when running various distributed jobs and particularly a failing `MultipleExecutionEnginesTest` which runs jobs using Tez and then fails with errors like the below:

> 2021-04-19T13:34:42,784 INFO  org.apache.hadoop.ipc.Client:940 - Retrying connect to server: fv-az83-66/10.1.0.22:38049. Already tried 9 time(s); retry policy is RetryUpToMaximumCountWithFixedSleep(maxRetries=10, sleepTime=1000 MILLISECONDS)
> 2021-04-19T13:34:42,813 INFO  org.apache.tez.client.TezClient:779 - Failed to retrieve AM Status via proxy
> com.google.protobuf.ServiceException: java.net.ConnectException: Call From fv-az83-66/10.1.0.22 to fv-az83-66:38049 failed on connection exception: java.net.ConnectException: Connection refused; For more details see:  http://wiki.apache.org/hadoop/ConnectionRefused
> 	at org.apache.hadoop.ipc.ProtobufRpcEngine$Invoker.invoke(ProtobufRpcEngine.java:242) ~[hadoop-common-3.1.0.jar:?]
> 	at org.apache.hadoop.ipc.ProtobufRpcEngine$Invoker.invoke(ProtobufRpcEngine.java:116) ~[hadoop-common-3.1.0.jar:?]
> 	at com.sun.proxy.$Proxy53.getAMStatus(Unknown Source) ~[?:?]
> 	at org.apache.tez.client.TezClient.getAppMasterStatus(TezClient.java:772) ~[tez-api-0.9.1.jar:0.9.1]
> 	at org.apache.tez.client.TezClient.waitTillReady(TezClient.java:909) ~[tez-api-0.9.1.jar:0.9.1]

Everything worked for me locally on different machines.

While debugging this I tried:

* Moving to Ubuntu `20.04` instead of `18.04` (this didn't seem to make any difference)
* Moving to `v2` of `setup-java` instead of `v1`) (this didn't seem to make any difference)
* Using `adopt` version of the JDK instead of the `setup-java` default version of `zulu` (this appears to have fixed the build)

Since this change appears to fix the build I'd like to merge this in and keep an eye on it over the next few commits and see how stable it is.