### PR TITLE
Upgrade to Hive 2.3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 NOTE: This CHANGELOG tracks changes in the 5.x (Hive 2.x) line. For 6.x (Hive 3.x) and above please refer to https://github.com/klarna/HiveRunner/blob/main/CHANGELOG.md.
 
-## [5.4.1] - 2023-01-23
+## [5.4.1] - 2023-01-20
 ### Changed
 - Upgraded Hive version to `2.3.9` (was `2.3.7`).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 NOTE: This CHANGELOG tracks changes in the 5.x (Hive 2.x) line. For 6.x (Hive 3.x) and above please refer to https://github.com/klarna/HiveRunner/blob/main/CHANGELOG.md.
 
+## [5.4.1] - 2023-01-23
+### Changed
+- Upgraded Hive version to `2.3.9` (was `2.3.7`).
+
 ## [5.4.0] - 2021-04-29
 ### Changed
 - Maven Group Id changed from `com.klarna` to `io.github.hiverunner`.

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,11 @@
   
   <dependencies>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>18.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-serde</artifactId>
       <version>${hive.version}</version>
@@ -171,14 +176,19 @@
     </dependency>
     
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-to-slf4j</artifactId>
-      <version>${log4j2.version}</version>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-slf4j-impl</artifactId>
+        <version>${log4j2.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
+      <artifactId>log4j-1.2-api</artifactId>
       <version>${log4j2.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.21</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -55,18 +55,18 @@
       <artifactId>hive-serde</artifactId>
       <version>${hive.version}</version>
       <exclusions>
-      	<exclusion>
-      		<groupId>log4j</groupId>
-      		<artifactId>log4j</artifactId>
+        <exclusion>
+          <groupId>log4j</groupId>
+      	  <artifactId>log4j</artifactId>
       	</exclusion>
       	<exclusion>
-      		<groupId>org.apache.logging.log4j</groupId>
-      		<artifactId>log4j-1.2-api</artifactId>
+      	  <groupId>org.apache.logging.log4j</groupId>
+      	  <artifactId>log4j-1.2-api</artifactId>
       	</exclusion>
       	<exclusion>
-      		<groupId>org.apache.logging.log4j</groupId>
-      		<artifactId>log4j-slf4j-impl</artifactId>
-      	</exclusion>
+      	  <groupId>org.apache.logging.log4j</groupId>
+      	  <artifactId>log4j-slf4j-impl</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 
@@ -75,10 +75,10 @@
       <artifactId>hive-jdbc</artifactId>
       <version>${hive.version}</version>
       <exclusions>
-      	<exclusion>
-      		<groupId>log4j</groupId>
-      		<artifactId>log4j</artifactId>
-      	</exclusion>
+        <exclusion>
+      	  <groupId>log4j</groupId>
+      	  <artifactId>log4j</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 
@@ -87,17 +87,17 @@
       <artifactId>hive-webhcat-java-client</artifactId>
       <version>${hive.version}</version>
       <exclusions>
-      	<exclusion>
-      		<groupId>log4j</groupId>
-      		<artifactId>log4j</artifactId>
+        <exclusion>
+      	  <groupId>log4j</groupId>
+      	  <artifactId>log4j</artifactId>
       	</exclusion>
       	<exclusion>
-      		<groupId>org.apache.logging.log4j</groupId>
-      		<artifactId>log4j-1.2-api</artifactId>
+      	  <groupId>org.apache.logging.log4j</groupId>
+      	  <artifactId>log4j-1.2-api</artifactId>
       	</exclusion>
       	<exclusion>
-      		<groupId>org.apache.logging.log4j</groupId>
-      		<artifactId>log4j-slf4j-impl</artifactId>
+      	  <groupId>org.apache.logging.log4j</groupId>
+      	  <artifactId>log4j-slf4j-impl</artifactId>
       	</exclusion>
       	<exclusion>
           <groupId>org.pentaho</groupId>
@@ -112,12 +112,12 @@
       <version>${hive.version}</version>
       <exclusions>
       	<exclusion>
-      		<groupId>log4j</groupId>
-      		<artifactId>log4j</artifactId>
+      	  <groupId>log4j</groupId>
+      	  <artifactId>log4j</artifactId>
       	</exclusion>
       	<exclusion>
-      		<groupId>org.slf4j</groupId>
-      		<artifactId>slf4j-log4j12</artifactId>
+      	  <groupId>org.slf4j</groupId>
+      	  <artifactId>slf4j-log4j12</artifactId>
       	</exclusion>
       	<exclusion>
           <groupId>org.pentaho</groupId>
@@ -132,12 +132,12 @@
       <version>${tez.version}</version>
       <exclusions>
       	<exclusion>
-      		<groupId>log4j</groupId>
-      		<artifactId>log4j</artifactId>
+      	  <groupId>log4j</groupId>
+      	  <artifactId>log4j</artifactId>
       	</exclusion>
       	<exclusion>
-      		<groupId>org.slf4j</groupId>
-      		<artifactId>slf4j-log4j12</artifactId>
+      	  <groupId>org.slf4j</groupId>
+      	  <artifactId>slf4j-log4j12</artifactId>
       	</exclusion>
       </exclusions>
     </dependency>
@@ -148,12 +148,12 @@
       <version>${tez.version}</version>
       <exclusions>
       	<exclusion>
-      		<groupId>log4j</groupId>
-      		<artifactId>log4j</artifactId>
+      	  <groupId>log4j</groupId>
+      	  <artifactId>log4j</artifactId>
       	</exclusion>
       	<exclusion>
-      		<groupId>org.slf4j</groupId>
-      		<artifactId>slf4j-log4j12</artifactId>
+      	  <groupId>org.slf4j</groupId>
+      	  <artifactId>slf4j-log4j12</artifactId>
       	</exclusion>
       </exclusions>
     </dependency>
@@ -164,8 +164,8 @@
       <version>${tez.version}</version>
       <exclusions>
       	<exclusion>
-      		<groupId>org.slf4j</groupId>
-      		<artifactId>slf4j-log4j12</artifactId>
+      	  <groupId>org.slf4j</groupId>
+      	  <artifactId>slf4j-log4j12</artifactId>
       	</exclusion>
       </exclusions>
     </dependency>
@@ -190,9 +190,9 @@
     </dependency>
     
     <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-slf4j-impl</artifactId>
-        <version>${log4j2.version}</version>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <version>${log4j2.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,10 @@
       		<groupId>org.apache.logging.log4j</groupId>
       		<artifactId>log4j-slf4j-impl</artifactId>
       	</exclusion>
+      	<exclusion>
+          <groupId>org.pentaho</groupId>
+          <artifactId>pentaho-aggdesigner-algorithm</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -36,11 +36,12 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <tez.version>0.9.1</tez.version>
-    <hive.version>2.3.7</hive.version>
+    <hive.version>2.3.9</hive.version>
     <license.maven.plugin.version>3.0</license.maven.plugin.version>
     <hive.execution.engine>mr</hive.execution.engine>
     <junit.jupiter.version>5.7.1</junit.jupiter.version>
     <mockito.version>3.8.0</mockito.version>
+    <log4j2.version>2.17.1</log4j2.version>
   </properties>
   
   <dependencies>
@@ -48,42 +49,112 @@
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-serde</artifactId>
       <version>${hive.version}</version>
+      <exclusions>
+      	<exclusion>
+      		<groupId>log4j</groupId>
+      		<artifactId>log4j</artifactId>
+      	</exclusion>
+      	<exclusion>
+      		<groupId>org.apache.logging.log4j</groupId>
+      		<artifactId>log4j-1.2-api</artifactId>
+      	</exclusion>
+      	<exclusion>
+      		<groupId>org.apache.logging.log4j</groupId>
+      		<artifactId>log4j-slf4j-impl</artifactId>
+      	</exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-jdbc</artifactId>
       <version>${hive.version}</version>
+      <exclusions>
+      	<exclusion>
+      		<groupId>log4j</groupId>
+      		<artifactId>log4j</artifactId>
+      	</exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
       <groupId>org.apache.hive.hcatalog</groupId>
       <artifactId>hive-webhcat-java-client</artifactId>
       <version>${hive.version}</version>
+      <exclusions>
+      	<exclusion>
+      		<groupId>log4j</groupId>
+      		<artifactId>log4j</artifactId>
+      	</exclusion>
+      	<exclusion>
+      		<groupId>org.apache.logging.log4j</groupId>
+      		<artifactId>log4j-1.2-api</artifactId>
+      	</exclusion>
+      	<exclusion>
+      		<groupId>org.apache.logging.log4j</groupId>
+      		<artifactId>log4j-slf4j-impl</artifactId>
+      	</exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-service</artifactId>
       <version>${hive.version}</version>
+      <exclusions>
+      	<exclusion>
+      		<groupId>log4j</groupId>
+      		<artifactId>log4j</artifactId>
+      	</exclusion>
+      	<exclusion>
+      		<groupId>org.slf4j</groupId>
+      		<artifactId>slf4j-log4j12</artifactId>
+      	</exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
       <artifactId>tez-dag</artifactId>
       <groupId>org.apache.tez</groupId>
       <version>${tez.version}</version>
+      <exclusions>
+      	<exclusion>
+      		<groupId>log4j</groupId>
+      		<artifactId>log4j</artifactId>
+      	</exclusion>
+      	<exclusion>
+      		<groupId>org.slf4j</groupId>
+      		<artifactId>slf4j-log4j12</artifactId>
+      	</exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
       <artifactId>tez-common</artifactId>
       <groupId>org.apache.tez</groupId>
       <version>${tez.version}</version>
+      <exclusions>
+      	<exclusion>
+      		<groupId>log4j</groupId>
+      		<artifactId>log4j</artifactId>
+      	</exclusion>
+      	<exclusion>
+      		<groupId>org.slf4j</groupId>
+      		<artifactId>slf4j-log4j12</artifactId>
+      	</exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
       <artifactId>tez-mapreduce</artifactId>
       <groupId>org.apache.tez</groupId>
       <version>${tez.version}</version>
+      <exclusions>
+      	<exclusion>
+      		<groupId>org.slf4j</groupId>
+      		<artifactId>slf4j-log4j12</artifactId>
+      	</exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -97,6 +168,22 @@
       <groupId>org.reflections</groupId>
       <artifactId>reflections</artifactId>
       <version>0.9.8</version>
+    </dependency>
+    
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-to-slf4j</artifactId>
+      <version>${log4j2.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>${log4j2.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>${log4j2.version}</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,12 @@
       <artifactId>hive-contrib</artifactId>
       <version>${hive.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.pentaho</groupId>
+          <artifactId>pentaho-aggdesigner-algorithm</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,10 @@
       		<groupId>org.slf4j</groupId>
       		<artifactId>slf4j-log4j12</artifactId>
       	</exclusion>
+      	<exclusion>
+          <groupId>org.pentaho</groupId>
+          <artifactId>pentaho-aggdesigner-algorithm</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 


### PR DESCRIPTION
I have also excluded log4J libraries that had the vulnerabilities and upgraded them.