### PR TITLE
Re-enable the license header plugin and reformat all the code using it

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -297,36 +297,36 @@
         </configuration>
       </plugin>
 
-<!--      <plugin>-->
-<!--        <groupId>com.mycila</groupId>-->
-<!--        <artifactId>license-maven-plugin</artifactId>-->
-<!--        <version>${license.maven.plugin.version}</version>-->
-<!--        <dependencies>-->
-<!--          <dependency>-->
-<!--            <groupId>com.mycila</groupId>-->
-<!--            <artifactId>license-maven-plugin-git</artifactId>-->
-<!--            <version>${license.maven.plugin.version}</version>-->
-<!--          </dependency>-->
-<!--        </dependencies>-->
-<!--        <configuration>-->
-<!--          <header>src/main/license/APACHE-2.txt</header>-->
-<!--          <properties>-->
-<!--            <owner>The HiveRunner Contributors</owner>-->
-<!--          </properties>-->
-<!--          <includes>-->
-<!--            <include>src/main/java/**</include>-->
-<!--            <include>src/test/java/**</include>-->
-<!--          </includes>-->
-<!--        </configuration>-->
-<!--        <executions>-->
-<!--          <execution>-->
-<!--            <phase>validate</phase>-->
-<!--            <goals>-->
-<!--              <goal>format</goal>-->
-<!--            </goals>-->
-<!--          </execution>-->
-<!--        </executions>-->
-<!--      </plugin>-->
+      <plugin>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <version>${license.maven.plugin.version}</version>
+        <dependencies>
+          <dependency>
+            <groupId>com.mycila</groupId>
+            <artifactId>license-maven-plugin-git</artifactId>
+            <version>${license.maven.plugin.version}</version>
+          </dependency>
+        </dependencies>
+        <configuration>
+          <header>src/main/license/APACHE-2.txt</header>
+          <properties>
+            <owner>The HiveRunner Contributors</owner>
+          </properties>
+          <includes>
+            <include>src/main/java/**</include>
+            <include>src/test/java/**</include>
+          </includes>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>validate</phase>
+            <goals>
+              <goal>format</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
 
      <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/com/klarna/hiverunner/HiveRunnerCore.java
+++ b/src/main/java/com/klarna/hiverunner/HiveRunnerCore.java
@@ -1,6 +1,6 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
- * Copyright (C) 2021 The HiveRunner Contributors
+ * Copyright (C) 2021-2024 The HiveRunner Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/klarna/hiverunner/HiveRunnerExtension.java
+++ b/src/main/java/com/klarna/hiverunner/HiveRunnerExtension.java
@@ -1,6 +1,6 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
- * Copyright (C) 2021 The HiveRunner Contributors
+ * Copyright (C) 2021-2024 The HiveRunner Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/klarna/hiverunner/HiveRunnerRule.java
+++ b/src/main/java/com/klarna/hiverunner/HiveRunnerRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/main/java/com/klarna/hiverunner/HiveServerContainer.java
+++ b/src/main/java/com/klarna/hiverunner/HiveServerContainer.java
@@ -1,6 +1,6 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
- * Copyright (C) 2021 The HiveRunner Contributors
+ * Copyright (C) 2021-2024 The HiveRunner Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/klarna/hiverunner/HiveServerContext.java
+++ b/src/main/java/com/klarna/hiverunner/HiveServerContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/main/java/com/klarna/hiverunner/HiveShell.java
+++ b/src/main/java/com/klarna/hiverunner/HiveShell.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/main/java/com/klarna/hiverunner/HiveShellContainer.java
+++ b/src/main/java/com/klarna/hiverunner/HiveShellContainer.java
@@ -1,6 +1,6 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
- * Copyright (C) 2021 The HiveRunner Contributors
+ * Copyright (C) 2021-2024 The HiveRunner Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/klarna/hiverunner/StandaloneHiveRunner.java
+++ b/src/main/java/com/klarna/hiverunner/StandaloneHiveRunner.java
@@ -1,6 +1,6 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
- * Copyright (C) 2021 The HiveRunner Contributors
+ * Copyright (C) 2021-2024 The HiveRunner Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/klarna/hiverunner/StandaloneHiveServerContext.java
+++ b/src/main/java/com/klarna/hiverunner/StandaloneHiveServerContext.java
@@ -1,6 +1,6 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
- * Copyright (C) 2021 The HiveRunner Contributors
+ * Copyright (C) 2021-2024 The HiveRunner Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/klarna/hiverunner/ThrowOnTimeout.java
+++ b/src/main/java/com/klarna/hiverunner/ThrowOnTimeout.java
@@ -1,6 +1,6 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
- * Copyright (C) 2021 The HiveRunner Contributors
+ * Copyright (C) 2021-2024 The HiveRunner Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/klarna/hiverunner/TimeoutException.java
+++ b/src/main/java/com/klarna/hiverunner/TimeoutException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/main/java/com/klarna/hiverunner/annotations/HiveProperties.java
+++ b/src/main/java/com/klarna/hiverunner/annotations/HiveProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/main/java/com/klarna/hiverunner/annotations/HiveResource.java
+++ b/src/main/java/com/klarna/hiverunner/annotations/HiveResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/main/java/com/klarna/hiverunner/annotations/HiveRunnerSetup.java
+++ b/src/main/java/com/klarna/hiverunner/annotations/HiveRunnerSetup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/main/java/com/klarna/hiverunner/annotations/HiveSQL.java
+++ b/src/main/java/com/klarna/hiverunner/annotations/HiveSQL.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/main/java/com/klarna/hiverunner/annotations/HiveSetupScript.java
+++ b/src/main/java/com/klarna/hiverunner/annotations/HiveSetupScript.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/main/java/com/klarna/hiverunner/builder/HiveResource.java
+++ b/src/main/java/com/klarna/hiverunner/builder/HiveResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/main/java/com/klarna/hiverunner/builder/HiveRunnerScript.java
+++ b/src/main/java/com/klarna/hiverunner/builder/HiveRunnerScript.java
@@ -1,6 +1,6 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
- * Copyright (C) 2021 The HiveRunner Contributors
+ * Copyright (C) 2021-2024 The HiveRunner Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/klarna/hiverunner/builder/HiveShellBase.java
+++ b/src/main/java/com/klarna/hiverunner/builder/HiveShellBase.java
@@ -1,6 +1,6 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
- * Copyright (C) 2021 The HiveRunner Contributors
+ * Copyright (C) 2021-2024 The HiveRunner Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/klarna/hiverunner/builder/HiveShellBuilder.java
+++ b/src/main/java/com/klarna/hiverunner/builder/HiveShellBuilder.java
@@ -1,6 +1,6 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
- * Copyright (C) 2021 The HiveRunner Contributors
+ * Copyright (C) 2021-2024 The HiveRunner Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/klarna/hiverunner/builder/HiveShellTearable.java
+++ b/src/main/java/com/klarna/hiverunner/builder/HiveShellTearable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/main/java/com/klarna/hiverunner/builder/Script.java
+++ b/src/main/java/com/klarna/hiverunner/builder/Script.java
@@ -1,6 +1,6 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
- * Copyright (C) 2021 The HiveRunner Contributors
+ * Copyright (C) 2021-2024 The HiveRunner Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/klarna/hiverunner/builder/Statement.java
+++ b/src/main/java/com/klarna/hiverunner/builder/Statement.java
@@ -1,6 +1,6 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
- * Copyright (C) 2021 The HiveRunner Contributors
+ * Copyright (C) 2021-2024 The HiveRunner Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/klarna/hiverunner/config/HiveRunnerConfig.java
+++ b/src/main/java/com/klarna/hiverunner/config/HiveRunnerConfig.java
@@ -1,6 +1,6 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
- * Copyright (C) 2021 The HiveRunner Contributors
+ * Copyright (C) 2021-2024 The HiveRunner Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/klarna/hiverunner/data/Converters.java
+++ b/src/main/java/com/klarna/hiverunner/data/Converters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/main/java/com/klarna/hiverunner/data/FileParser.java
+++ b/src/main/java/com/klarna/hiverunner/data/FileParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/main/java/com/klarna/hiverunner/data/InsertIntoTable.java
+++ b/src/main/java/com/klarna/hiverunner/data/InsertIntoTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/main/java/com/klarna/hiverunner/data/TableDataBuilder.java
+++ b/src/main/java/com/klarna/hiverunner/data/TableDataBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/main/java/com/klarna/hiverunner/data/TableDataInserter.java
+++ b/src/main/java/com/klarna/hiverunner/data/TableDataInserter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/main/java/com/klarna/hiverunner/data/TsvFileParser.java
+++ b/src/main/java/com/klarna/hiverunner/data/TsvFileParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/main/java/com/klarna/hiverunner/io/IgnoreClosePrintStream.java
+++ b/src/main/java/com/klarna/hiverunner/io/IgnoreClosePrintStream.java
@@ -1,6 +1,6 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
- * Copyright (C) 2021 The HiveRunner Contributors
+ * Copyright (C) 2021-2024 The HiveRunner Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/klarna/hiverunner/sql/HiveRunnerStatement.java
+++ b/src/main/java/com/klarna/hiverunner/sql/HiveRunnerStatement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/main/java/com/klarna/hiverunner/sql/StatementLexer.java
+++ b/src/main/java/com/klarna/hiverunner/sql/StatementLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/main/java/com/klarna/hiverunner/sql/cli/AbstractImportPostProcessor.java
+++ b/src/main/java/com/klarna/hiverunner/sql/cli/AbstractImportPostProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/main/java/com/klarna/hiverunner/sql/cli/CommandShellEmulator.java
+++ b/src/main/java/com/klarna/hiverunner/sql/cli/CommandShellEmulator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/main/java/com/klarna/hiverunner/sql/cli/CommandShellEmulatorFactory.java
+++ b/src/main/java/com/klarna/hiverunner/sql/cli/CommandShellEmulatorFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/main/java/com/klarna/hiverunner/sql/cli/CommentUtil.java
+++ b/src/main/java/com/klarna/hiverunner/sql/cli/CommentUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/main/java/com/klarna/hiverunner/sql/cli/DefaultPreProcessor.java
+++ b/src/main/java/com/klarna/hiverunner/sql/cli/DefaultPreProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/main/java/com/klarna/hiverunner/sql/cli/PostProcessor.java
+++ b/src/main/java/com/klarna/hiverunner/sql/cli/PostProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/main/java/com/klarna/hiverunner/sql/cli/PreProcessor.java
+++ b/src/main/java/com/klarna/hiverunner/sql/cli/PreProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/main/java/com/klarna/hiverunner/sql/cli/beeline/BeelineEmulator.java
+++ b/src/main/java/com/klarna/hiverunner/sql/cli/beeline/BeelineEmulator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/main/java/com/klarna/hiverunner/sql/cli/beeline/RunCommandPostProcessor.java
+++ b/src/main/java/com/klarna/hiverunner/sql/cli/beeline/RunCommandPostProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/main/java/com/klarna/hiverunner/sql/cli/beeline/SqlLineCommandRule.java
+++ b/src/main/java/com/klarna/hiverunner/sql/cli/beeline/SqlLineCommandRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/main/java/com/klarna/hiverunner/sql/cli/hive/HiveCliEmulator.java
+++ b/src/main/java/com/klarna/hiverunner/sql/cli/hive/HiveCliEmulator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/main/java/com/klarna/hiverunner/sql/cli/hive/PreV200HiveCliEmulator.java
+++ b/src/main/java/com/klarna/hiverunner/sql/cli/hive/PreV200HiveCliEmulator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/main/java/com/klarna/hiverunner/sql/cli/hive/PreV200HiveCliPreProcessor.java
+++ b/src/main/java/com/klarna/hiverunner/sql/cli/hive/PreV200HiveCliPreProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/main/java/com/klarna/hiverunner/sql/cli/hive/SourceCommandPostProcessor.java
+++ b/src/main/java/com/klarna/hiverunner/sql/cli/hive/SourceCommandPostProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/main/java/com/klarna/hiverunner/sql/split/BaseContext.java
+++ b/src/main/java/com/klarna/hiverunner/sql/split/BaseContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/main/java/com/klarna/hiverunner/sql/split/CloseStatementRule.java
+++ b/src/main/java/com/klarna/hiverunner/sql/split/CloseStatementRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/main/java/com/klarna/hiverunner/sql/split/Consumer.java
+++ b/src/main/java/com/klarna/hiverunner/sql/split/Consumer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/main/java/com/klarna/hiverunner/sql/split/Context.java
+++ b/src/main/java/com/klarna/hiverunner/sql/split/Context.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/main/java/com/klarna/hiverunner/sql/split/DefaultTokenRule.java
+++ b/src/main/java/com/klarna/hiverunner/sql/split/DefaultTokenRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/main/java/com/klarna/hiverunner/sql/split/NewLineUtil.java
+++ b/src/main/java/com/klarna/hiverunner/sql/split/NewLineUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/main/java/com/klarna/hiverunner/sql/split/PreserveCommentsRule.java
+++ b/src/main/java/com/klarna/hiverunner/sql/split/PreserveCommentsRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/main/java/com/klarna/hiverunner/sql/split/PreserveQuotesRule.java
+++ b/src/main/java/com/klarna/hiverunner/sql/split/PreserveQuotesRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/main/java/com/klarna/hiverunner/sql/split/StatementSplitter.java
+++ b/src/main/java/com/klarna/hiverunner/sql/split/StatementSplitter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/main/java/com/klarna/hiverunner/sql/split/TokenRule.java
+++ b/src/main/java/com/klarna/hiverunner/sql/split/TokenRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/main/java/com/klarna/reflection/ReflectionUtils.java
+++ b/src/main/java/com/klarna/reflection/ReflectionUtils.java
@@ -1,6 +1,6 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
- * Copyright (C) 2021 The HiveRunner Contributors
+ * Copyright (C) 2021-2024 The HiveRunner Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/klarna/hiverunner/AggregateViewTest.java
+++ b/src/test/java/com/klarna/hiverunner/AggregateViewTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/AnnotatedBaseTestClass.java
+++ b/src/test/java/com/klarna/hiverunner/AnnotatedBaseTestClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/AnnotatedFieldsInSuperClassTest.java
+++ b/src/test/java/com/klarna/hiverunner/AnnotatedFieldsInSuperClassTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/BeelineRunTest.java
+++ b/src/test/java/com/klarna/hiverunner/BeelineRunTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/BigResultSetTest.java
+++ b/src/test/java/com/klarna/hiverunner/BigResultSetTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/CommentTest.java
+++ b/src/test/java/com/klarna/hiverunner/CommentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/CtasTest.java
+++ b/src/test/java/com/klarna/hiverunner/CtasTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/DisabledTimeoutTest.java
+++ b/src/test/java/com/klarna/hiverunner/DisabledTimeoutTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/ExecuteFileBasedScriptIntegrationTest.java
+++ b/src/test/java/com/klarna/hiverunner/ExecuteFileBasedScriptIntegrationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/ExecuteScriptIntegrationTest.java
+++ b/src/test/java/com/klarna/hiverunner/ExecuteScriptIntegrationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/HiveCliSourceTest.java
+++ b/src/test/java/com/klarna/hiverunner/HiveCliSourceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/HiveRunnerAnnotationsTest.java
+++ b/src/test/java/com/klarna/hiverunner/HiveRunnerAnnotationsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/HiveRunnerExtensionTest.java
+++ b/src/test/java/com/klarna/hiverunner/HiveRunnerExtensionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/HiveServerContainerTest.java
+++ b/src/test/java/com/klarna/hiverunner/HiveServerContainerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/HiveShellBeeLineEmulationTest.java
+++ b/src/test/java/com/klarna/hiverunner/HiveShellBeeLineEmulationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/HiveShellHiveCliEmulationTest.java
+++ b/src/test/java/com/klarna/hiverunner/HiveShellHiveCliEmulationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/HiveVariablesTest.java
+++ b/src/test/java/com/klarna/hiverunner/HiveVariablesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/InsertIntoTableIntegrationTest.java
+++ b/src/test/java/com/klarna/hiverunner/InsertIntoTableIntegrationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/IntegerPartitionFormatTest.java
+++ b/src/test/java/com/klarna/hiverunner/IntegerPartitionFormatTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/InteractiveHiveShellTest.java
+++ b/src/test/java/com/klarna/hiverunner/InteractiveHiveShellTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/LeftOuterJoinTest.java
+++ b/src/test/java/com/klarna/hiverunner/LeftOuterJoinTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/MSCKRepairNpeTest.java
+++ b/src/test/java/com/klarna/hiverunner/MSCKRepairNpeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/MacroTest.java
+++ b/src/test/java/com/klarna/hiverunner/MacroTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/MethodLevelResourceTest.java
+++ b/src/test/java/com/klarna/hiverunner/MethodLevelResourceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/MultipleExecutionEnginesTest.java
+++ b/src/test/java/com/klarna/hiverunner/MultipleExecutionEnginesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/NeverEndingUdf.java
+++ b/src/test/java/com/klarna/hiverunner/NeverEndingUdf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/NoTimeoutTest.java
+++ b/src/test/java/com/klarna/hiverunner/NoTimeoutTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/OrcSnappyTest.java
+++ b/src/test/java/com/klarna/hiverunner/OrcSnappyTest.java
@@ -1,6 +1,6 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
- * Copyright (C) 2021 The HiveRunner Contributors
+ * Copyright (C) 2021-2024 The HiveRunner Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/klarna/hiverunner/ParquetInsertionTest.java
+++ b/src/test/java/com/klarna/hiverunner/ParquetInsertionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/PartitionSupportTest.java
+++ b/src/test/java/com/klarna/hiverunner/PartitionSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/ReservedKeywordTest.java
+++ b/src/test/java/com/klarna/hiverunner/ReservedKeywordTest.java
@@ -1,6 +1,6 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
- * Copyright (C) 2021 The HiveRunner Contributors
+ * Copyright (C) 2021-2024 The HiveRunner Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/klarna/hiverunner/ResourceOutputStreamTest.java
+++ b/src/test/java/com/klarna/hiverunner/ResourceOutputStreamTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/SchemaResetBetweenTestMethodsTest.java
+++ b/src/test/java/com/klarna/hiverunner/SchemaResetBetweenTestMethodsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/SerdeTest.java
+++ b/src/test/java/com/klarna/hiverunner/SerdeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/SetHiveExecutionEngineTest.java
+++ b/src/test/java/com/klarna/hiverunner/SetHiveExecutionEngineTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/SetPropertyTest.java
+++ b/src/test/java/com/klarna/hiverunner/SetPropertyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/SetTest.java
+++ b/src/test/java/com/klarna/hiverunner/SetTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/SlowlyFailingUdf.java
+++ b/src/test/java/com/klarna/hiverunner/SlowlyFailingUdf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/TestMethodIntegrityTest.java
+++ b/src/test/java/com/klarna/hiverunner/TestMethodIntegrityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/TimeoutAndRetryTest.java
+++ b/src/test/java/com/klarna/hiverunner/TimeoutAndRetryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/ToUpperCaseSerDe.java
+++ b/src/test/java/com/klarna/hiverunner/ToUpperCaseSerDe.java
@@ -1,6 +1,6 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
- * Copyright (C) 2021 The HiveRunner Contributors
+ * Copyright (C) 2021-2024 The HiveRunner Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/klarna/hiverunner/UnresolvedResourcePathTest.java
+++ b/src/test/java/com/klarna/hiverunner/UnresolvedResourcePathTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/UserDefinedFunctionTest.java
+++ b/src/test/java/com/klarna/hiverunner/UserDefinedFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/builder/HiveShellBaseTest.java
+++ b/src/test/java/com/klarna/hiverunner/builder/HiveShellBaseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/config/HiveRunnerConfigTest.java
+++ b/src/test/java/com/klarna/hiverunner/config/HiveRunnerConfigTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/data/ConvertersTest.java
+++ b/src/test/java/com/klarna/hiverunner/data/ConvertersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/data/InsertIntoTableTest.java
+++ b/src/test/java/com/klarna/hiverunner/data/InsertIntoTableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/data/TableDataBuilderTest.java
+++ b/src/test/java/com/klarna/hiverunner/data/TableDataBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/data/TableDataInserterTest.java
+++ b/src/test/java/com/klarna/hiverunner/data/TableDataInserterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/data/TsvFileParserTest.java
+++ b/src/test/java/com/klarna/hiverunner/data/TsvFileParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/examples/HelloAnnotatedHiveRunnerTest.java
+++ b/src/test/java/com/klarna/hiverunner/examples/HelloAnnotatedHiveRunnerTest.java
@@ -1,6 +1,6 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
- * Copyright (C) 2021 The HiveRunner Contributors
+ * Copyright (C) 2021-2024 The HiveRunner Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/klarna/hiverunner/examples/HelloHiveRunnerParamaterizedTest.java
+++ b/src/test/java/com/klarna/hiverunner/examples/HelloHiveRunnerParamaterizedTest.java
@@ -1,6 +1,6 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
- * Copyright (C) 2021 The HiveRunner Contributors
+ * Copyright (C) 2021-2024 The HiveRunner Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/klarna/hiverunner/examples/HelloHiveRunnerTest.java
+++ b/src/test/java/com/klarna/hiverunner/examples/HelloHiveRunnerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/examples/InsertTestDataTest.java
+++ b/src/test/java/com/klarna/hiverunner/examples/InsertTestDataTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/examples/SetHiveConfValuesTest.java
+++ b/src/test/java/com/klarna/hiverunner/examples/SetHiveConfValuesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/examples/junit4/HelloAnnotatedHiveRunnerTest.java
+++ b/src/test/java/com/klarna/hiverunner/examples/junit4/HelloAnnotatedHiveRunnerTest.java
@@ -1,6 +1,6 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
- * Copyright (C) 2021 The HiveRunner Contributors
+ * Copyright (C) 2021-2024 The HiveRunner Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/klarna/hiverunner/examples/junit4/HelloHiveRunnerTest.java
+++ b/src/test/java/com/klarna/hiverunner/examples/junit4/HelloHiveRunnerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/examples/junit4/InsertTestDataTest.java
+++ b/src/test/java/com/klarna/hiverunner/examples/junit4/InsertTestDataTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/examples/junit4/SetHiveConfValuesTest.java
+++ b/src/test/java/com/klarna/hiverunner/examples/junit4/SetHiveConfValuesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/io/IgnoreClosePrintStreamTest.java
+++ b/src/test/java/com/klarna/hiverunner/io/IgnoreClosePrintStreamTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/sql/cli/AbstractImportPostProcessorTest.java
+++ b/src/test/java/com/klarna/hiverunner/sql/cli/AbstractImportPostProcessorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/sql/cli/CommandShellEmulatorFactoryTest.java
+++ b/src/test/java/com/klarna/hiverunner/sql/cli/CommandShellEmulatorFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/sql/cli/CommentUtilTest.java
+++ b/src/test/java/com/klarna/hiverunner/sql/cli/CommentUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/sql/cli/beeline/BeelineEmulatorTest.java
+++ b/src/test/java/com/klarna/hiverunner/sql/cli/beeline/BeelineEmulatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/sql/cli/beeline/BeelineStatementSplitterTest.java
+++ b/src/test/java/com/klarna/hiverunner/sql/cli/beeline/BeelineStatementSplitterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/sql/cli/beeline/RunCommandPostProcessorTest.java
+++ b/src/test/java/com/klarna/hiverunner/sql/cli/beeline/RunCommandPostProcessorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/sql/cli/beeline/SqlLineCommandRuleTest.java
+++ b/src/test/java/com/klarna/hiverunner/sql/cli/beeline/SqlLineCommandRuleTest.java
@@ -1,6 +1,6 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
- * Copyright (C) 2021 The HiveRunner Contributors
+ * Copyright (C) 2021-2024 The HiveRunner Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/klarna/hiverunner/sql/cli/hive/HiveCliEmulatorTest.java
+++ b/src/test/java/com/klarna/hiverunner/sql/cli/hive/HiveCliEmulatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/sql/cli/hive/HiveCliStatementSplitterTest.java
+++ b/src/test/java/com/klarna/hiverunner/sql/cli/hive/HiveCliStatementSplitterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/sql/cli/hive/PreV200HiveCliEmulatorTest.java
+++ b/src/test/java/com/klarna/hiverunner/sql/cli/hive/PreV200HiveCliEmulatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/sql/cli/hive/SourceCommandPostProcessorTest.java
+++ b/src/test/java/com/klarna/hiverunner/sql/cli/hive/SourceCommandPostProcessorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/sql/split/BaseContextTest.java
+++ b/src/test/java/com/klarna/hiverunner/sql/split/BaseContextTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/sql/split/CloseStatementRuleTest.java
+++ b/src/test/java/com/klarna/hiverunner/sql/split/CloseStatementRuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/sql/split/ConsumerEolTest.java
+++ b/src/test/java/com/klarna/hiverunner/sql/split/ConsumerEolTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/sql/split/DefaultTokenRuleTest.java
+++ b/src/test/java/com/klarna/hiverunner/sql/split/DefaultTokenRuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/sql/split/NewLineUtilTest.java
+++ b/src/test/java/com/klarna/hiverunner/sql/split/NewLineUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/sql/split/PreserveCommentsRuleTest.java
+++ b/src/test/java/com/klarna/hiverunner/sql/split/PreserveCommentsRuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/sql/split/PreserveQuotesRuleTest.java
+++ b/src/test/java/com/klarna/hiverunner/sql/split/PreserveQuotesRuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *

--- a/src/test/java/com/klarna/hiverunner/sql/split/StatementSplitterTest.java
+++ b/src/test/java/com/klarna/hiverunner/sql/split/StatementSplitterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2021 Klarna AB
  * Copyright (C) 2021 The HiveRunner Contributors
  *


### PR DESCRIPTION
I put the license header plugin back into the pom and re-ran `license:format` and it seems to have done the right thing.